### PR TITLE
docs: sync bugpocer CLI and GitHub Action docs with prod

### DIFF
--- a/src/content/docs/cli/bugpocer.mdx
+++ b/src/content/docs/cli/bugpocer.mdx
@@ -101,12 +101,46 @@ olympix bug-pocer
 | `-env, --include-dot-env` | Include `.env` file for fork testing secrets (RPC URLs, API keys, etc.) |
 | `--env-file` | Path to a custom `.env` file (requires `-env`) |
 | `-ext, --extension` | Additional file extensions to include (can be used multiple times) |
+| `-rc, --rebuild-context` | Force a fresh project-context build, ignoring the [context cache](#context-cache) |
+| `-sp, --skip-preflight` | Skip the local [pre-flight validation](#pre-flight-validation) (build check) before upload |
+| `-ca, --confirm-all` | Auto-confirm scope, documentation, cache, and pre-flight prompts (non-interactive; implied in CI) |
 
 :::tip[Including env variables]
 If your tests need `RPC URLs`, `API keys`, `private keys`, etc., pass them with `-env` (reads from `.env`) or `--env-file <path>` for a custom file. Use whatever `.env` format your project's test framework already reads (e.g. `KEY=value` lines).
 
 This is the recommended way to pass env variables — the file is encrypted in transit with an extra RSA layer on top of the regular channel encryption.
 :::
+
+---
+
+## Pre-flight Validation
+
+Before anything is uploaded, the CLI runs a local **pre-flight check** that confirms your project actually builds. Because BugPoCer ships your locally-built artifacts, a project that doesn't compile on your machine can't be analyzed — pre-flight catches that up front instead of failing server-side.
+
+What it checks, by framework:
+
+- **Foundry** — `forge` is on your `PATH`, git submodules are present, `foundry.toml` remappings resolve, an import-resolution sweep passes, and `forge build` succeeds.
+- **Hardhat** — `node_modules` and `package.json` are present and `hardhat compile` succeeds.
+- **Anchor / Rust / Cairo** — build artifacts exist and the manifest (`Cargo.toml` / `Scarb.toml` / `Anchor.toml`) is readable.
+
+If a blocking issue is found, the CLI prints remediation steps and asks whether to continue anyway or abort. In non-interactive runs (CI, PR mode, or `--confirm-all`) it logs a warning and proceeds.
+
+| Control | Effect |
+|---------|--------|
+| `-sp` / `--skip-preflight` | Skip pre-flight entirely. |
+| `OLYMPIX_PREFLIGHT_BUILD_TIMEOUT_SECONDS` (env var) | Override the build-step timeout. Default: `120`. |
+
+---
+
+## Context Cache
+
+BugPoCer caches the project context it builds so repeat scans don't start from scratch. The cache is keyed on your source files, so the CLI knows whether your code has changed since the last run:
+
+- **Exact match** (no files changed) — interactively you're offered **Approve** (reuse as-is), **Update** (reuse as a baseline and fold in new docs), or **Rebuild**. In non-interactive runs the cache is reused automatically.
+- **Partial match** (some files changed) — the cached context seeds a faster incremental rebuild.
+- **No cache** — context is built from scratch.
+
+Pass `-rc` / `--rebuild-context` to ignore the cache and force a fresh build every time.
 
 ---
 
@@ -190,11 +224,15 @@ In addition to the interactive picker, you can pre-seed scope with a config file
 
 #### Default ignore list
 
-BugPoCer automatically excludes common non-production paths. For Solidity projects, files whose path contains any of the following are always ignored:
+BugPoCer automatically excludes common non-production and dependency paths. Entries are matched as **case-insensitive path segments** — a whole `/`-delimited path segment must match, not an arbitrary substring.
 
-`node_modules`, `test`, `mock`, `example`, `dependencies`, `forge-std`, `openzeppelin`, `solmate`, `solady`, `prb-math`, `prb-test`, `murky`, `permit2`, `v3-core`, `v3-periphery`, `v2-core`, `v2-periphery`
+For **Solidity** projects, any file with one of these path segments is ignored:
 
-Rust and Cairo projects use language-specific exclusion sets instead (typical directories like `tests`, `target`, `vendor`, `.snfoundry_cache`, `fixtures`, `benches`, `examples`).
+`node_modules`, `dependencies`, `forge-std`, `ds-test`, `openzeppelin`, `openzeppelin-contracts`, `openzeppelin-contracts-upgradeable`, `openzeppelin-foundry-upgrades`, `solmate`, `solady`, `prb-math`, `prb-test`, `murky`, `permit2`, `erc4626-tests`, `erc6900`, `v2-core`, `v2-periphery`, `v3-core`, `v3-periphery`, `v4-core`, `v4-periphery`, `uniswap-v2`, `uniswap-v3`, `uniswap-v4`, `aave-v2`, `aave-v3`, `chainlink`, `chainlink-brownie-contracts`, `balancer-v2`, `curve`
+
+For **Rust** projects: `target`, `test`, `tests`, `mock`, `mocks`, `example`, `examples`, `node_modules`.
+
+For **Cairo** projects: `target`, `test`, `tests`, `mock`, `mocks`, `mock_contracts`, `example`, `examples`, `node_modules`, `.snfoundry_cache`.
 
 :::note[Difference from other Olympix tools]
 BugPoCer does **not** use the general `IgnoredPaths`, `TrustedPaths`, `TrustedVariables`, or `TrustedContracts` options. Use `BugPocerScopePaths` and `BugPocerIgnorePaths` instead.
@@ -232,7 +270,7 @@ Once the server has built its understanding of your project, you'll receive the 
 
 ### What gets validated
 
-BugPoCer infers eight categories of context:
+BugPoCer infers nine categories of context:
 
 - **Identity** — what the project is (name, type)
 - **Intent / Description** — what the project does
@@ -242,6 +280,7 @@ BugPoCer infers eight categories of context:
 - **Invariants** — properties that must always hold (one item per invariant)
 - **Design Decisions** — documented intentional behaviors and known limitations (one item per decision)
 - **Security Assumptions** — trust boundaries and assumptions about external entities
+- **Dependencies** — external libraries and protocols the project relies on
 
 Inferences the engine is already confident about are auto-confirmed and don't appear in the validation queue. You only see the items the engine is unsure of.
 
@@ -325,7 +364,6 @@ Taking the time to mark each finding pays off twice. Your verdicts show up in ev
 | `Backspace` | Clear user verdict |
 | `t` | Toggle TP-only filter |
 | `v` | Toggle filter source (engine verdict vs. user verdict) |
-| `d` | Download currently displayed findings / context as Markdown |
 | `b` | Back to menu |
 | `q` | Quit the findings view |
 
@@ -382,7 +420,7 @@ The PDF contains:
 - **Unverified Findings**, same structure, for engine-flagged issues whose PoC didn't compile
 - **False Positive Findings**, same structure
 
-Saved to your current working directory as `BugPoCer_<sessionId>_<timestamp>.pdf`.
+Saved to your current working directory as `BugPoCer_Scan_Report_<sessionId>_<timestamp>.pdf`.
 
 ### PoC test files
 

--- a/src/content/docs/github-actions/bugpocer.mdx
+++ b/src/content/docs/github-actions/bugpocer.mdx
@@ -5,11 +5,17 @@ description: Run BugPoCer in CI on pull requests.
 
 import { Steps } from '@astrojs/starlight/components';
 
-The Olympix BugPocer action runs Olympix's AI-powered agentic security analysis on Solidity smart
-contracts directly inside your pull-request workflow. BugPocer reasons about your code the way a
-human auditor would — building a project context, ranking the highest-impact functions, and
-generating proof-of-concept exploits for any vulnerabilities it finds — and posts its results back
-to the PR for review.
+The Olympix BugPocer action runs Olympix's AI-powered agentic security analysis on your smart
+contracts — Solidity, Rust (Anchor/Solana), and Cairo (StarkNet) — directly inside your
+pull-request workflow. BugPocer reasons about your code the way a human auditor would — building a
+project context, ranking the highest-impact functions, and generating proof-of-concept exploits for
+any vulnerabilities it finds — and posts its results back to the PR for review.
+
+:::note[Toolchain per language]
+The example workflows below are for Solidity/Foundry projects. Rust and Cairo projects work the
+same way, but swap the Foundry setup steps for your stack's toolchain (e.g. `anchor build` /
+`cargo-build-sbf`, or `scarb build` + `snforge`) so the project builds in CI before the scan runs.
+:::
 
 You can access this action from the [GitHub Marketplace](https://github.com/marketplace/actions/olympix-bugpocer)
 or visit the [GitHub repository](https://github.com/olympix/bugpocer-action).
@@ -25,7 +31,7 @@ auditor that:
 - Reads the PR diff and surrounding context
 - Selects the most impactful contracts and functions to analyze
 - Verifies and severity-scores each vulnerability it finds
-- Generates a Foundry proof-of-concept and posts review comments back to the PR
+- Generates a proof-of-concept in the project's native test framework (Foundry, `cargo test`, or `snforge`) and posts review comments back to the PR
 
 The action supports two trigger modes:
 
@@ -229,6 +235,14 @@ jobs:
 | `GITHUB_REPOSITORY_ID` | Yes | The numeric repository ID (`${{ github.repository_id }}`). |
 | `OLYMPIX_TRIGGER_COMMIT_MESSAGE` | Manual-mode `pull_request` events only | Captured from `git log -1 --pretty=%B`. Lets the trigger parser read the commit body for `/bugpocer scan`. |
 
+:::note[Wired up for you]
+In PR mode BugPocer also reads several variables that you don't normally set by hand: the GitHub
+runner provides `GITHUB_EVENT_NAME`, `GITHUB_EVENT_PATH`, `GITHUB_BASE_REF`, and `GITHUB_HEAD_REF`
+automatically, and the action supplies `OLYMPIX_GITHUB_ACCESS_TOKEN` (used to post review comments)
+and `OLYMPIX_INTEGRATION_ORIGIN`. They're listed here for completeness — the table above covers
+everything you actually configure.
+:::
+
 ---
 
 ## Action Inputs
@@ -237,7 +251,7 @@ The action accepts a single `args` input that is forwarded to the Olympix CLI. T
 flags are:
 
 - **`-w | --workspace-path`** — Project root directory. *Default:* current directory.
-- **`-ca | --confirm-all-questions`** — Skip the interactive scope-review and additional-docs prompts. Optional in CI (the non-TTY environment already suppresses prompts), but harmless to leave in the example workflows.
+- **`-ca | --confirm-all`** — Skip the interactive scope-review and additional-docs prompts. Optional in CI (the non-TTY environment already suppresses prompts), but harmless to leave in the example workflows.
 
 ---
 


### PR DESCRIPTION
## Summary

Audited both bugpocer doc pages against the deployed CLI/implementation (`~/olympix/test2/olympix-dotnet`) and fixed the gaps found. No source changes — docs only.

### CLI page (`cli/bugpocer.mdx`)
- **Added missing flags:** `-rc, --rebuild-context`, `-sp, --skip-preflight`, and `-ca, --confirm-all` to the options table.
- **New "Pre-flight Validation" section** — per-framework local build checks (Foundry/Hardhat/Anchor/Rust/Cairo), the `OLYMPIX_PREFLIGHT_BUILD_TIMEOUT_SECONDS` override, and how `--skip-preflight` bypasses it.
- **New "Context Cache" section** — Approve/Update/Rebuild behavior and what `--rebuild-context` forces.
- **Corrected default ignore list** — it's case-insensitive *path-segment* matching (not substring); the Solidity dependency list is now complete (~30 entries); `test`/`mock`/`example` moved to the Rust/Cairo lists where they actually apply.
- **Added 9th context-validation category** (`Dependencies`).
- **Removed the non-existent `d` key** from the findings-pager keybinding table.
- **Fixed PDF export filename** → `BugPoCer_Scan_Report_<sessionId>_<timestamp>.pdf`.

### GitHub Action page (`github-actions/bugpocer.mdx`)
- **Broadened Solidity-only framing** to Solidity, Rust (Anchor/Solana), and Cairo, with a note that the example workflows are Foundry-specific.
- **Fixed flag name** `--confirm-all-questions` → `--confirm-all`.
- **Documented auto-wired PR-mode env vars** (`GITHUB_EVENT_NAME`/`GITHUB_EVENT_PATH`, `GITHUB_BASE_REF`/`GITHUB_HEAD_REF`, `OLYMPIX_GITHUB_ACCESS_TOKEN`, `OLYMPIX_INTEGRATION_ORIGIN`).

Intentionally left out (per request): undocumented `*-bp-session` subcommands and the `Pending`/`PendingCompletion` session statuses.

## Test plan
- `npm run build` ✓ (17 pages, no errors)
- Verified both pages render (HTTP 200) and all new sections/fixes appear via the local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)