### PR TITLE
docs: surface Claude Code plugin on the docs homepage

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -34,6 +34,11 @@ Welcome to the official Olympix documentation! Here you'll find everything you n
     href="/vscode-extension/"
     description="Integrated features in your editor — real-time scanning and quick fixes."
   />
+  <LinkCard
+    title="Claude Code Plugin"
+    href="https://github.com/olympix/olympix-claude-plugin"
+    description="Install the Olympix skills for Claude Code — run every tool through agent mode automatically."
+  />
 </CardGrid>
 
 ---


### PR DESCRIPTION
## What

Adds a `LinkCard` to the [Olympix Claude plugin](https://github.com/olympix/olympix-claude-plugin) in the homepage **Contents** grid, for visibility alongside Installation, CLI, GitHub Actions, and VSCode.

Follow-up to #21 (which added the plugin to the CLI agent-mode docs).

## Verified locally

`npm run build` passes (19 pages, clean) and previewed on `localhost:4321`.

> Note: the plugin repo `olympix/olympix-claude-plugin` is still **private**, so this card 404s for public visitors until the repo is made public — same caveat as #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)